### PR TITLE
Remove Unneeded Code - provides speedup

### DIFF
--- a/ocdsdata/base.py
+++ b/ocdsdata/base.py
@@ -130,7 +130,6 @@ class Source:
                 if info['errors'] and not metadata['gather_failure_datetime']:
                     metadata['gather_failure_datetime'] = str(datetime.datetime.utcnow())
                     failed = True
-                self.save_metadata(metadata)
         except Exception as e:
             metadata['gather_failure_exception'] = repr(e)
             metadata['gather_failure_datetime'] = str(datetime.datetime.utcnow())


### PR DESCRIPTION
Currently we are saving meta_data at every loop of the gather stage.

This seems unneeded as it saves at the end anyway?

And we aren't able to resume from here - and in any case no external requests happen in that loop - so save in the loop doesn't provide any benifits?

And it's really slow. For mexibo_cdmx gather stage only, with the save it takes 25 Secs. Without the save it takes 3 Secs. And that's only data on ~1000 urls it's trying to save - other scrapers have far more.

Before we remove this, is there another purpose to this that I'm missing?