### PR TITLE
Quit successfully after creating database

### DIFF
--- a/ocdsdata-cli
+++ b/ocdsdata-cli
@@ -38,10 +38,12 @@ def main():
         if args.verbose:
             print("Creating Database")
         create_tables(False)
+        quit(0)
     elif args.dropandcreatedatabase:
         if args.verbose:
             print("Dropping and Recreating Database")
         create_tables(True)
+        quit(0)
 
     run = []
 


### PR DESCRIPTION
At the moment, we quit with error if someone doesn't specify anything to run. When trying to deploy this to the server, we don't want to do a run, but we do want to set up the database. 