### PR TITLE
Fetch Errors - Make sure Meta DB records them properly

### DIFF
--- a/ocdsdata/base.py
+++ b/ocdsdata/base.py
@@ -166,12 +166,12 @@ class Source:
                     errors = [repr(e)]
 
                 if errors:
-                    self.metadata_db.update_filestatus_fetch_end(data['filename'], False, str(errors))
+                    self.metadata_db.update_filestatus_fetch_end(data['filename'], False, errors)
                     failed = True
                 else:
                     self.metadata_db.update_filestatus_fetch_end(data['filename'], True)
 
-        self.metadata_db.update_session_fetch_end(not failed) ## No ERrors Passed here?
+        self.metadata_db.update_session_fetch_end(not failed)
 
     """Uploads the fetched data as record rows to the Database"""
     def run_store(self):

--- a/ocdsdata/metadata_db.py
+++ b/ocdsdata/metadata_db.py
@@ -34,7 +34,6 @@ class MetadataDB(object):
 
             sa.Column('fetch_start_datetime', sa.DateTime, nullable=True),
             sa.Column('fetch_finished_datetime', sa.DateTime, nullable=True),
-            sa.Column('fetch_errors', sa.Text, nullable=True),
             sa.Column('fetch_success', sa.Boolean, nullable=False, default=False),
         )
 
@@ -103,7 +102,7 @@ class MetadataDB(object):
             return conn.execute(stmt)
 
     """Updates filestatus when fetched, takes boolean success flag, and a string of errors."""
-    def update_filestatus_fetch_end(self, filename, success, errors = None):
+    def update_filestatus_fetch_end(self, filename, success, errors = []):
         stmt = self.filestatus.update().\
             where(self.filestatus.c.filename == filename).\
             values(fetch_finished_datetime=datetime.datetime.now(),
@@ -138,10 +137,9 @@ class MetadataDB(object):
             return conn.execute(stmt)
 
     """Updates session when done fetching, takes boolean success flag, and json string of errors."""
-    def update_session_fetch_end(self, success, errors = None):
+    def update_session_fetch_end(self, success):
         stmt = self.session.update().values(
                                     fetch_success = success,
-                                    fetch_errors = errors,
                                     fetch_finished_datetime=datetime.datetime.now())
         with self.engine.connect() as conn:
             return conn.execute(stmt)
@@ -160,6 +158,7 @@ class MetadataDB(object):
             for data in result:
                 data = dict(data)
                 data['gather_errors'] = json.loads(data['gather_errors']) if data['gather_errors'] else None
+                data['fetch_errors'] = json.loads(data['fetch_errors']) if data['fetch_errors'] else None
                 row['file_status'][data['filename']] = data
 
             return row

--- a/ocdsdata/tests.py
+++ b/ocdsdata/tests.py
@@ -131,6 +131,76 @@ def test_bad_gather():
             fetcher.run_fetch()
 
 
+class BadFetchErrors(Source):
+    publisher_name = 'test'
+    url = 'test_url'
+    source_id = 'test'
+    data_version = 'v1'
+
+    def gather_all_download_urls(self):
+        yield {'url': 'https://raw.githubusercontent.com/open-contracting/sample-data/5bcbfcf48bf6e6599194b8acae61e2c6e8fb5009/fictional-example/1.1/ocds-213czf-000-00001-02-tender.json',
+               'filename': 'file1.json',
+               'data_type': 'releases',
+               'errors': []}
+
+    def save_url(self, file_name, data, file_path):
+        return [], ['A really bad error occured!']
+
+
+def test_bad_fetch_errors():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fetcher = BadFetchErrors(tmpdir)
+        fetcher.run_gather()
+        fetcher.run_fetch()
+
+        metadata_db = MetadataDB(join(tmpdir, 'test', 'v1'))
+        data = metadata_db.get_dict()
+        assert data['gather_success']
+        assert data['gather_finished_datetime']
+        assert not data['fetch_success']
+        assert not data['file_status']['file1.json']['fetch_success']
+        assert data['file_status']['file1.json']['fetch_start_datetime']
+        assert data['file_status']['file1.json']['fetch_finished_datetime']
+        assert data['file_status']['file1.json']['fetch_errors'] == ['A really bad error occured!']
+
+        with pytest.raises(Exception):
+            fetcher.run_store()
+
+class BadFetchException(Source):
+    publisher_name = 'test'
+    url = 'test_url'
+    source_id = 'test'
+    data_version = 'v1'
+
+    def gather_all_download_urls(self):
+        yield {'url': 'https://raw.githubusercontent.com/open-contracting/sample-data/5bcbfcf48bf6e6599194b8acae61e2c6e8fb5009/fictional-example/1.1/ocds-213czf-000-00001-02-tender.json',
+               'filename': 'file1.json',
+               'data_type': 'releases',
+               'errors': []}
+
+    def save_url(self, file_name, data, file_path):
+        raise Exception('Whoops')
+
+
+def test_bad_fetch_exception():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fetcher = BadFetchException(tmpdir)
+        fetcher.run_gather()
+        fetcher.run_fetch()
+
+        metadata_db = MetadataDB(join(tmpdir, 'test', 'v1'))
+        data = metadata_db.get_dict()
+        assert data['gather_success']
+        assert data['gather_finished_datetime']
+        assert not data['fetch_success']
+        assert not data['file_status']['file1.json']['fetch_success']
+        assert data['file_status']['file1.json']['fetch_start_datetime']
+        assert data['file_status']['file1.json']['fetch_finished_datetime']
+        assert data['file_status']['file1.json']['fetch_errors'] == ["Exception('Whoops',)"]
+
+        with pytest.raises(Exception):
+            fetcher.run_store()
+
 class ExceptionGather(Source):
     publisher_name = 'test'
     url = 'test_url'


### PR DESCRIPTION
Fetch Errors - Make sure Meta DB records them properly - minor tweak to ensure that they are saved as JSON properly

Don't store on session table - this is just a duplicate of what's on filestatus table and it may get very large (I'm thinking of Colombia, that may have a thousand fetch errors because the high page numbers mostly throw 500 errors. Now, each error will be stored in the appropriate row in filestatus table. Previously, we would also have a giant JSON list stored on session table that would just be a duplicate anyway.)

And some automatic tests around this.

https://github.com/open-contracting/ocdsdata/issues/71