### PR TITLE
Start of Status command, a CLI tool that shows current progress of an operation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Run `ocdsdata-cli` with the argument of one of the publishers you want to fetch.
 
 Set the `DB_URI` enviromental variable to use a custom PostgreSQL server, the default is `postgres://ocdsdata:ocdsdata@localhost/ocdsdata`
 
+## Status of a run
+
+During or after a run you can use a command to check on the progress.
+
+Run `ocdsdata-status` with the source flag as the publisher you want to see. Pass the sample flag to, if it's a sample run.
+
+By default it will show the progress for the latest run, but you can pass the dataversion flag to see different ones.
+
 ## Run Tests
 
 Run `py.test` from root directory.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Set the `DB_URI` enviromental variable to use a custom PostgreSQL server, the de
 
 During or after a run you can use a command to check on the progress.
 
-Run `ocdsdata-status` with the source flag as the publisher you want to see. Pass the sample flag to, if it's a sample run.
+Run `ocdsdata-status` with the source flag as the publisher you want to see. Pass the sample flag too, if it's a sample run.
 
 By default it will show the progress for the latest run, but you can pass the dataversion flag to see different ones.
 

--- a/ocdsdata-status
+++ b/ocdsdata-status
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import argparse
+import os
+from ocdsdata.status import SourceStatus
+
+
+def main():
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", help="Which source do you want to see status for?")
+    parser.add_argument("--dataversion", help="Specify a data version - defaults to latest one")
+    parser.add_argument("--sample", help="See status for a sample", action="store_true")
+    parser.add_argument("--basedir", help="base dir - defaults to 'data' on current directory")
+    parser.add_argument("--outputdir", help="output dir - defaults to source id.")
+
+    args = parser.parse_args()
+
+    this_dir = os.path.dirname(os.path.realpath(__file__))
+    base_dir = args.basedir or os.path.join(this_dir, "data")
+
+    source_id = args.source
+
+    source_status = SourceStatus(base_dir=base_dir,
+                                 source_id=source_id,
+                                 output_directory=args.outputdir,
+                                 sample=args.sample,
+                                 data_version=args.dataversion
+                                 )
+
+    print("Status for: %s (Output Dir: %s, Data Version: %s)" % (source_id, source_status.output_directory, source_status.data_version))
+
+    if not source_status.is_gather_finished():
+        print("####### Gather Progress")
+        print(source_status.get_gather_progress_as_text())
+    elif not source_status.is_fetch_finished():
+        print("####### Fetch Progress")
+        print(source_status.get_fetch_progress_as_text())
+    elif not source_status.is_store_finished():
+        print("####### Store Progress")
+        print(source_status.get_store_progress_as_text())
+    else:
+        print("Gather, Fetch and Store all Finished!")
+
+
+if __name__ == '__main__':
+    main()

--- a/ocdsdata/status.py
+++ b/ocdsdata/status.py
@@ -1,0 +1,88 @@
+import os
+from .metadata_db import MetadataDB
+from . import database
+
+
+class SourceStatus:
+
+    def __init__(self, base_dir, source_id, output_directory=None, sample=False, data_version=None):
+
+        self.base_dir = base_dir
+        self.source_id = source_id
+        self.sample = sample
+
+        # Make sure the output directory is fully specified, including sample bit (if applicable)
+        self.output_directory = output_directory or source_id
+        if not self.output_directory:
+            raise AttributeError('An output directory needs to be specified')
+
+        if self.sample and not self.output_directory.endswith('_sample'):
+            self.output_directory += '_sample'
+
+        # Load all versions if possible, pick an existing one or set a new one.
+        all_versions = sorted(os.listdir(os.path.join(base_dir, self.output_directory)), reverse=True)\
+            if os.path.exists(os.path.join(base_dir, self.output_directory)) else []
+
+        if data_version and data_version in all_versions:  # Version specified is valid
+            self.data_version = data_version
+        elif data_version:   # Version specified is invalid!
+            raise AttributeError('A version was specified that does not exist')
+        elif len(all_versions) > 0:  # Get the latest version to resume
+            self.data_version = all_versions[0]
+        else:  # Should not happen...
+            raise AttributeError('The source and/or version is unavailable on the output directory')
+
+        # Build full directory, make sure it exists
+        self.full_directory = os.path.join(base_dir, self.output_directory, self.data_version)
+        if not os.path.exists(self.full_directory):
+            raise AttributeError('Full Directory does not exist!')
+
+        # Misc
+        self.metadata_db = MetadataDB(self.full_directory)
+
+    def is_gather_finished(self):
+        metadata = self.metadata_db.get_session()
+        return bool(metadata['gather_finished_datetime'])
+
+    def get_gather_progress_as_text(self):
+
+        out = []
+        metadata = self.metadata_db.get_session()
+
+        if metadata['gather_start_datetime']:
+            out.append("Started " + metadata['gather_start_datetime'].strftime("%c"))
+
+        return "\n".join(out)
+
+    def is_fetch_finished(self):
+        metadata = self.metadata_db.get_session()
+        return bool(metadata['fetch_finished_datetime'])
+
+    def get_fetch_progress_as_text(self):
+
+        file_statuses = self.metadata_db.list_filestatus()
+        count_finished = 0
+        current_out = []
+
+        for file_status in file_statuses:
+            if file_status['fetch_finished_datetime'] is not None:
+                count_finished += 1
+
+            if file_status['fetch_start_datetime'] and file_status['fetch_finished_datetime'] is None:
+                current_out.append("Filename: " + file_status['filename'])
+                current_out.append("URL: " + file_status['url'])
+                current_out.append("Data Type: " + file_status['data_type'])
+                current_out.append("Encoding: " + file_status['encoding'])
+                current_out.append("Started: " + file_status['fetch_start_datetime'].strftime("%c"))
+
+        out = "Finished " + str(count_finished) + " out of " + str(len(file_statuses)) + " files.\n"
+        if current_out:
+            return out + "\nIn Progress:\n" + "\n".join(current_out)
+        else:
+            return out
+
+    def is_store_finished(self):
+        return database.is_store_done(self.source_id, self.data_version, self.sample)
+
+    def get_store_progress_as_text(self):
+        return 'Store is in progress'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='ocdsdata',
             'ocdsdata.maindatabase.migrations',
             'ocdsdata.maindatabase.migrations.versions'
       ],
-      scripts=['ocdsdata-cli'],
+      scripts=['ocdsdata-cli', 'ocdsdata-status'],
       package_data={'ocdsdata': [
               'maindatabase/migrations/script.py.mako'
           ]},


### PR DESCRIPTION
Use case: When a process is running, it would be great to see the current progress. This morning I wanted to check a fetch stage in progress and all the cli tool says is "fetching"!

(Because I know how the app works I could just look in the DB and see - but of course others won't and shouldn't have to know how to do that.)

Here is some sample outputs:

> (.ve) vagrant@ubuntu-xenial:/vagrant$ ./ocdsdata-status  --source canada_buyandsell
> Status for: canada_buyandsell (Output Dir: canada_buyandsell, Data Version: 2018-06-15-13-10-28)
> ####### Gather Progress
> Started Fri Jun 15 13:10:28 2018



> (.ve) vagrant@ubuntu-xenial:/vagrant$ ./ocdsdata-status  --source canada_buyandsell
> Status for: canada_buyandsell (Output Dir: canada_buyandsell, Data Version: 2018-06-15-13-10-28)
> ####### Fetch Progress
> Finished 0 out of 4 files.
> 
> In Progress:
> Filename: 2013-14.json
> URL: https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-13-14.json
> Data Type: release_package
> Encoding: utf-8
> Started: Fri Jun 15 13:10:38 2018




> (.ve) vagrant@ubuntu-xenial:/vagrant$ ./ocdsdata-status  --source canada_buyandsell
> Status for: canada_buyandsell (Output Dir: canada_buyandsell, Data Version: 2018-06-15-13-10-28)
> ####### Fetch Progress
> Finished 1 out of 4 files.
> 
> In Progress:
> Filename: 2014-15.json
> URL: https://buyandsell.gc.ca/cds/public/ocds/tpsgc-pwgsc_ocds_EF-FY-14-15.json
> Data Type: release_package
> Encoding: utf-8
> Started: Fri Jun 15 13:10:53 2018





> (.ve) vagrant@ubuntu-xenial:/vagrant$ ./ocdsdata-status  --source canada_buyandsell
> Status for: canada_buyandsell (Output Dir: canada_buyandsell, Data Version: 2018-06-15-13-10-28)
> ####### Store Progress
> Store is in progress




> (.ve) vagrant@ubuntu-xenial:/vagrant$ ./ocdsdata-status  --source canada_buyandsell
> Status for: canada_buyandsell (Output Dir: canada_buyandsell, Data Version: 2018-06-15-13-10-28)
> Gather, Fetch and Store all Finished!

By default it shows current progress - I think that's the right thing. Could add more to this - an option to see errors encountered would be the first priority, I would guess. But could also add option to show more details, list files, etc ...

Other things to improve:
  *  Show better progress report on store phrase! (How far completed it is)
  *  When #109 is merged to master, we should show progress of the checks stage in this tool.
  *  Note this is a seperate cli command - see #113 about making subcommands for other things and include this in that work.
  *  Better error messages if people specify sources that don't exist.

But wanted to put this up for merge now so the basic framework is in there (already this would have been useful for me this morning!), and also so I didn't go to far without consulting others more widely than I already have done. Once it's merged in I can make issues for other things and other people can work on it to.


