### PR TITLE
Filter out control codes in the framework.

### DIFF
--- a/ocdsdata/sources/moldova.py
+++ b/ocdsdata/sources/moldova.py
@@ -1,6 +1,5 @@
 from ocdsdata.base import Source
 from ocdsdata.util import save_content
-import os
 
 
 class MoldovaSource(Source):
@@ -32,15 +31,4 @@ class MoldovaSource(Source):
 
     # @rate_limited(1)
     def save_url(self, filename, data, file_path):
-        errors = save_content(data['url'], file_path + '-download.json')
-        if errors:
-            return [], errors
-
-        with open(file_path + '-download.json') as infile:
-            with open(file_path, 'w') as outfile:
-                for line in infile:
-                    outfile.write(line.replace('\\u0000', ''))
-
-        os.remove(file_path + '-download.json')
-
-        return [], []
+        return [], save_content(data['url'], file_path)

--- a/ocdsdata/sources/ukraine.py
+++ b/ocdsdata/sources/ukraine.py
@@ -1,7 +1,6 @@
 import hashlib
 
 import lxml.html
-import os
 
 from ocdsdata import util
 from ocdsdata.base import Source
@@ -70,15 +69,4 @@ class UkraineSource(Source):
             return additional, []
 
         else:
-            errors = save_content(data['url'], file_path + '-download.json')
-            if errors:
-                return [], errors
-
-            with open(file_path + '-download.json') as infile:
-                with open(file_path, 'w') as outfile:
-                    for line in infile:
-                        outfile.write(line.replace('\\u0000', ''))
-
-            os.remove(file_path + '-download.json')
-
-            return [], []
+            return [], save_content(data['url'], file_path)

--- a/ocdsdata/util.py
+++ b/ocdsdata/util.py
@@ -39,6 +39,25 @@ def get_url_request(url, headers=None, stream=False, tries=1, errors=None):
     return get_url_request(url, headers, stream, tries + 1, errors)
 
 
+control_codes_to_filter_out = [
+    b'\\u0000',
+    b'\x02',
+    b'\x04',
+    b'\x05',
+    b'\x07',
+    b'\x0B',
+    b'\x0E',
+    b'\x11',
+    b'\x12',
+    b'\x13',
+    b'\x14',
+    b'\x15',
+    b'\x17',
+    b'\x19',
+    b'\x1A',
+]
+
+
 def save_content(url, filepath, headers=None):
     request, errors = get_url_request(url, stream=True, headers=headers)
 
@@ -48,6 +67,9 @@ def save_content(url, filepath, headers=None):
     try:
         with open(filepath, 'wb') as f:
             for chunk in request.iter_content(1024 ^ 2):
+                for control_code_to_filter_out in control_codes_to_filter_out:
+                    if control_code_to_filter_out in chunk:
+                        chunk = chunk.replace(control_code_to_filter_out, b'')
                 f.write(chunk)
         return []
     except Exception as e:


### PR DESCRIPTION
Now individual sources don't have to do this.
https://github.com/open-contracting/ocdsdata/issues/96
https://github.com/open-contracting/ocdsdata/issues/103

Tested on uk_contracts_finder, colombia, moldova - fixes all.

I can't duplicate on ukraine - the sample works fine. @robredpath You added this - did you take any notes on which file exactly had this problem? (I don't want to run full download to find out if I can avoid that!)

The code is deliberately structured with a for loop and an if statement with an eye to #105 - it should be easy to add another line to that if statement going 

> warnings.append("We had to filter out control char X from url Y")

However, the framework doesn't currently have the concept of Warnings. So there will be a bit of work to add that in, and change existing sources to accommodate that. Therefore I thought I should do that in a different pull request, if this one is accepted.

Also note I've only listed the problem characters seen so far. Maybe we should try and list all the early control codes?