### PR TITLE
Database Config - allow a config file not to have a password.

### DIFF
--- a/ocdsdata/maindatabase/config.py
+++ b/ocdsdata/maindatabase/config.py
@@ -19,7 +19,7 @@ if not env_db_uri:
     port = config.get('DBHOST', 'PORT')
     user = config.get('DBHOST', 'USERNAME')
     dbname = config.get('DBHOST', 'DBNAME')
-    dbpass = config.get('DBHOST', 'PASSWORD')
+    dbpass = config.get('DBHOST', 'PASSWORD', fallback='')
 
     def __gen_dburi(user, password, host, port, dbname):
         return 'postgresql://{}:{}@{}:{}/{}'.format(user, password, host, port, dbname)


### PR DESCRIPTION
Before, if you wanted to have host, port, user and name set in the config file but password set in pgpass, you still had to have a password entry in the config file or it would crash.

Fixes that crash.