### PR TITLE
Start Sphinx Docs

### DIFF
--- a/docs/cli-run.rst
+++ b/docs/cli-run.rst
@@ -1,0 +1,3 @@
+Command line tool - run option
+==============================
+

--- a/docs/cli-status.rst
+++ b/docs/cli-status.rst
@@ -1,0 +1,4 @@
+Command line tool - status option
+=================================
+
+

--- a/docs/cli-upgrade-database.rst
+++ b/docs/cli-upgrade-database.rst
@@ -1,0 +1,4 @@
+Command line tool - upgrade-database option
+===========================================
+
+

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,8 @@
+Command line tool
+=================
+
+.. toctree::
+
+   cli-run.rst
+   cli-status.rst
+   cli-upgrade-database.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,4 @@
+master_doc = 'index'
+
+project = 'OCDS Data Tool'
+copyright = '2018, Open Contracting Data Standard'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,6 @@
+OCDSData tool
+=============
+
+.. toctree::
+
+   cli.rst


### PR DESCRIPTION
https://github.com/open-contracting/ocdsdata/issues/126

This can be seen at https://ocdsdata.readthedocs.io/en/start-docs/index.html

It just sets up the basic files and adds some pages we know we want.

Once this is in, I'm happy to look at a big pull request that moves content from the readme to the Sphinx docs and adds lots more content.